### PR TITLE
Change 'Client ID' to 'Customer ID'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Bitstamp credentials needed for private calls
-# Client ID can be found at https://www.bitstamp.net/account/balance/
+# Customer ID can be found at https://www.bitstamp.net/account/balance/
 BITSTAMP_KEY=key
 BITSTAMP_SECRET=secret
-BITSTAMP_CLIENT_ID=client-id
+BITSTAMP_CUSTOMER_ID=customer-id

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can update your .env file with the following settings (only needed for priva
 ```
 BITSTAMP_KEY=key
 BITSTAMP_SECRET=secret
-BITSTAMP_CLIENT_ID=client-id
+BITSTAMP_CUSTOMER_ID=customer-id
 ```
 ## Usage
 

--- a/config/bitstamp.php
+++ b/config/bitstamp.php
@@ -7,6 +7,6 @@ return [
     // API Secret key
     'secret' => env('BITSTAMP_SECRET'),
 
-    // API Version
-    'client_id' => env('BITSTAMP_CLIENT_ID'),
+    // Customer ID
+    'customer_id' => env('BITSTAMP_CUSTOMER_ID'),
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,6 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BITSTAMP_KEY" value="key"/>
         <env name="BITSTAMP_SECRET" value="secret"/>
-        <env name="BITSTAMP_CLIENT_ID" value="clientId"/>
+        <env name="BITSTAMP_CUSTOMER_ID" value="customerId"/>
     </php>
 </phpunit>

--- a/src/BitstampServiceProvider.php
+++ b/src/BitstampServiceProvider.php
@@ -33,7 +33,7 @@ class BitstampServiceProvider extends ServiceProvider
                 new HttpClient(),
                 $config['key'] ?? null,
                 $config['secret'] ?? null,
-                $config['client_id'] ?? null
+                $config['customer_id'] ?? null
             );
         });
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -39,7 +39,7 @@ class Client implements ClientContract
      *
      * @var string
      */
-    protected $clientId;
+    protected $customerId;
 
     /**
      * @var HttpClient
@@ -50,14 +50,14 @@ class Client implements ClientContract
      * @param HttpClient $client
      * @param string     $key      API key
      * @param string     $secret   API secret
-     * @param string     $clientId client id (can be found in account balance)
+     * @param string     $customerId customer id (can be found in account balance)
      */
-    public function __construct(HttpClient $client, ?string $key = '', ?string $secret = '', ?string $clientId = '')
+    public function __construct(HttpClient $client, ?string $key = '', ?string $secret = '', ?string $customerId = '')
     {
         $this->client = $client;
         $this->key = $key;
         $this->secret = $secret;
-        $this->clientId = $clientId;
+        $this->customerId = $customerId;
     }
 
     /**
@@ -305,7 +305,7 @@ class Client implements ClientContract
      */
     protected function generateSign(): string
     {
-        $message = $this->nonce.$this->clientId.$this->key;
+        $message = $this->nonce.$this->customerId.$this->key;
 
         return strtoupper(hash_hmac('sha256', $message, $this->secret));
     }

--- a/tests/PrivateClientTest.php
+++ b/tests/PrivateClientTest.php
@@ -25,7 +25,7 @@ class PrivateClientTest extends TestCase
             new HttpClient(),
             getenv('BITSTAMP_KEY') ?? null,
             getenv('BITSTAMP_SECRET') ?? null,
-            getenv('BITSTAMP_CLIENT_ID') ?? null
+            getenv('BITSTAMP_CUSTOMER_ID') ?? null
         );
     }
 


### PR DESCRIPTION
Change all occurrences of "Client ID" to "Customer ID" to be consistent with "Account" page on Bitstamp.net and avoid any confusion.